### PR TITLE
Fixed failed alarms when TZ != GMT

### DIFF
--- a/ESP8266TimeAlarms.h
+++ b/ESP8266TimeAlarms.h
@@ -134,7 +134,10 @@ public:
     tma.tm_min = M;
     tma.tm_sec = S;
     t2 = mktime(&tma);
-    return t2-previousMidnight(t1);
+    int diff = t2-previousMidnight(t1);
+    if (diff > SECS_PER_DAY)
+      diff -= SECS_PER_DAY;
+    return diff;
 }
   // functions to create alarms and timers
 


### PR DESCRIPTION
In some cases when TZ != GMT, setting alarms when the day is different between the 2 timezones will fail.
This fixes the problem by making sure the difference between alarm time and prev midnight is not bigger than one day.